### PR TITLE
Update pom.xml for cts2-framework for Maven and environment changes

### DIFF
--- a/cts2-webapp/pom.xml
+++ b/cts2-webapp/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<org.aspectj-version>1.8.0</org.aspectj-version>
 		<org.slf4j-version>1.7.5</org.slf4j-version>
-		<spring-security.version>3.1.0.RC3</spring-security.version>
+		<spring-security.version>3.1.0.RELEASE</spring-security.version>
 		<jetty.version>6.1.26</jetty.version>
         <context.path>cts2</context.path>
         <port>8888</port>

--- a/pom.xml
+++ b/pom.xml
@@ -484,9 +484,9 @@
 	<repositories>
 		<!-- For testing against latest Spring snapshots -->
 		<repository>
-			<id>org.springframework.maven.snapshot</id>
-			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<id>repository.spring.snapshot</id>
+			<name>Spring Snapshot Repository</name>
+			<url>https://repo.spring.io/snapshot</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>
@@ -496,9 +496,9 @@
 		</repository>
 		<!-- For developing against latest Spring milestones -->
 		<repository>
-			<id>org.springframework.maven.milestone</id>
-			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<id>repository.spring.milestone</id>
+			<name>Spring Milestone Repository</name>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -507,17 +507,17 @@
 		<repository>
 			<id>com.springsource.repository.bundles.release</id>
 			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.external</id>
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/external</url>
+			<url>https://repository.springsource.com/maven/bundles/external</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.milestone</id>
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/milestone</url>
+			<url>https://repository.springsource.com/maven/bundles/milestone</url>
 		</repository>
 
 <!--		<repository>-->
@@ -532,7 +532,7 @@
 		</repository>
 		<repository>
 			<id>clojars</id>
-			<url>http://clojars.org/repo/</url>
+			<url>https://repo.clojars.org/</url>
 		</repository>
 
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.mayo.cts2</groupId>
 	<artifactId>cts2-framework</artifactId>
@@ -79,18 +79,32 @@
 	</distributionManagement>
 
 	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.8</version>
-				<configuration>
-					<minmemory>128m</minmemory>
-					<maxmemory>512m</maxmemory>
-					<additionalJOption>-J-XX:MaxPermSize=512m</additionalJOption>
-				</configuration>
-			</plugin>
-		</plugins>
+	<plugins>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-javadoc-plugin</artifactId>
+			<version>2.8</version>
+			<configuration>
+				<minmemory>128m</minmemory>
+				<maxmemory>512m</maxmemory>
+				<additionalJOption>-J-XX:MaxPermSize=512m</additionalJOption>
+			</configuration>
+		</plugin>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-jxr-plugin</artifactId>
+			<version>2.3</version>
+		</plugin>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-project-info-reports-plugin</artifactId>
+			<version>2.2</version>
+			<configuration>
+				<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+				<dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+			</configuration>
+		</plugin>
+	</plugins>
 	</reporting>
 
 	<build>
@@ -271,34 +285,34 @@
 						<version>1.0</version>
 					</dependency>
 				</dependencies>
-				<configuration>
-					<reportPlugins>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-javadoc-plugin</artifactId>
-							<version>2.8</version>
-							<configuration>
-					          	<minmemory>128m</minmemory>
-								<maxmemory>512m</maxmemory>
-								<additionalJOption>-J-XX:MaxPermSize=512m</additionalJOption>
-					        </configuration>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-jxr-plugin</artifactId>
-							<version>2.3</version>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-project-info-reports-plugin</artifactId>
-							<version>2.2</version>
-                            <configuration>
-                                <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                                <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
-                            </configuration>
-						</plugin>
-					</reportPlugins>
-				</configuration>
+<!--				<configuration>-->
+<!--					<reportPlugins>-->
+<!--						<plugin>-->
+<!--							<groupId>org.apache.maven.plugins</groupId>-->
+<!--							<artifactId>maven-javadoc-plugin</artifactId>-->
+<!--							<version>2.8</version>-->
+<!--							<configuration>-->
+<!--					          	<minmemory>128m</minmemory>-->
+<!--								<maxmemory>512m</maxmemory>-->
+<!--								<additionalJOption>-J-XX:MaxPermSize=512m</additionalJOption>-->
+<!--					        </configuration>-->
+<!--						</plugin>-->
+<!--						<plugin>-->
+<!--							<groupId>org.apache.maven.plugins</groupId>-->
+<!--							<artifactId>maven-jxr-plugin</artifactId>-->
+<!--							<version>2.3</version>-->
+<!--						</plugin>-->
+<!--						<plugin>-->
+<!--							<groupId>org.apache.maven.plugins</groupId>-->
+<!--							<artifactId>maven-project-info-reports-plugin</artifactId>-->
+<!--							<version>2.2</version>-->
+<!--                            <configuration>-->
+<!--                                <dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+<!--                                <dependencyDetailsEnabled>false</dependencyDetailsEnabled>-->
+<!--                            </configuration>-->
+<!--						</plugin>-->
+<!--					</reportPlugins>-->
+<!--				</configuration>-->
 			</plugin>
 			
 				<plugin>
@@ -506,11 +520,11 @@
 			<url>http://repository.springsource.com/maven/bundles/milestone</url>
 		</repository>
 
-		<repository>
-			<id>scala-tools.org</id>
-			<name>Scala-Tools Maven2 Repository</name>
-			<url>http://scala-tools.org/repo-releases</url>
-		</repository>
+<!--		<repository>-->
+<!--			<id>scala-tools.org</id>-->
+<!--			<name>Scala-Tools Maven2 Repository</name>-->
+<!--			<url>http://scala-tools.org/repo-releases</url>-->
+<!--		</repository>-->
 
 		<repository>
 			<id>clojure-releases</id>


### PR DESCRIPTION
3.1.0.RC3 is no longer a 'published' release and has moved to full 3.1.0.RELEASE

maven-4.0.0.xsd is now at an https location

The reportPlugins structure is no longer preferred and throws errors.  Moved to "reporting" section as "plugins"

The maven.springframework.org site is deprecated and replaced by https://repo.spring.io

Maven 3.7+ has started blocking insecure mirrors. (https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291) 
repository.springsource is now https

clojars url is now https

scala url is no longer a valid link.  I could find no replacement and I don't know why this appears.

"maven clean install" and "maven test" was successful after these changes